### PR TITLE
feat: enable Claude review for specific user with sticky comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,10 +13,7 @@ on:
 jobs:
   claude-review:
     # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.pull_request.user.login == 'tdkn'
 
     runs-on: ubuntu-latest
     permissions:
@@ -52,7 +49,7 @@ jobs:
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          use_sticky_comment: true
 
           # Optional: Customize review based on file types
           # direct_prompt: |


### PR DESCRIPTION
Enable Claude code review workflow only for pull requests from user
'tdkn'. This focuses automated reviews on a specific contributor
rather than filtering by association type.

Also enable sticky comments to reuse the same comment thread on
subsequent pushes to the same PR, reducing comment noise and
maintaining context across review iterations.