### PR TITLE
fix(ci): optimize workflow by reordering steps and adding cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,12 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Check Node version
+        working-directory: .
+        run: |
+          chmod +x ./scripts/check-node-version.sh
+          ./scripts/check-node-version.sh
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
@@ -30,14 +36,16 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "pnpm"
 
-      - name: Check Node version
-        working-directory: .
-        run: |
-          chmod +x ./scripts/check-node-version.sh
-          ./scripts/check-node-version.sh
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.[jt]sx?') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
 
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
Move Node version check before pnpm setup to fail fast on version
mismatch. Add Next.js build cache to speed up subsequent builds by
caching the .next/cache directory based on dependencies and source
files. This reduces build times in CI pipelines.