### PR TITLE
chore: enable devcontainer manager in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "timezone": "Asia/Tokyo",
   "extends": ["config:recommended", "schedule:weekdays"],
   "rangeStrategy": "pin",
-  "enabledManagers": ["npm", "nvm"],
+  "enabledManagers": ["npm", "nvm", "devcontainer"],
   "reviewers": ["tdkn"],
   "automerge": true,
   "platformAutomerge": true,
@@ -11,6 +11,10 @@
     {
       "matchManagers": ["npm"],
       "labels": ["dependencies", "javascript"]
+    },
+    {
+      "matchManagers": ["devcontainer"],
+      "labels": ["dependencies", "devcontainer"]
     }
   ]
 }


### PR DESCRIPTION
Add devcontainer to the list of enabled managers to allow Renovate
to automatically update development container dependencies. This
ensures that devcontainer base images and features stay up-to-date
alongside npm and nvm dependencies.