### PR TITLE
feat: add conditional execution to CI workflow

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -1,0 +1,31 @@
+node-version:
+  - ".nvmrc"
+  - ".node-version"
+  - "package.json"
+  - "scripts/check-node-version.sh"
+
+pnpm:
+  - "pnpm-lock.yaml"
+  - "package.json"
+
+source:
+  - "src/**"
+  - "posts/**"
+  - "*.config.*"
+  - "*.json"
+  - "*.yaml"
+  - "*.yml"
+
+build:
+  - "src/**"
+  - "posts/**"
+  - "public/**"
+  - "next.config.js"
+  - "tsconfig.json"
+  - "tailwind.config.ts"
+  - "postcss.config.js"
+
+test:
+  - "src/**"
+  - "vitest.config.ts"
+  - "tsconfig.json"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,28 +22,40 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Detect file changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: .github/filters.yaml
+
       - name: Check Node version
+        if: steps.changes.outputs.node == 'true' || steps.changes.outputs.source == 'true'
         working-directory: .
         run: |
           chmod +x ./scripts/check-node-version.sh
           ./scripts/check-node-version.sh
 
       - name: Install pnpm
+        if: steps.changes.outputs.pnpm == 'true' || steps.changes.outputs.source == 'true'
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
       - name: Cache pnpm store
+        if: steps.changes.outputs.pnpm == 'true' || steps.changes.outputs.source == 'true'
         run: pnpm store path
 
       - name: Setup Node.js
+        if: steps.changes.outputs.node == 'true' || steps.changes.outputs.pnpm == 'true' || steps.changes.outputs.source == 'true'
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
 
       - name: Install dependencies
+        if: steps.changes.outputs.pnpm == 'true' || steps.changes.outputs.source == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Restore Next.js cache
+        if: steps.changes.outputs.build == 'true'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/.next/cache
@@ -52,10 +64,13 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
 
       - name: Build
+        if: steps.changes.outputs.build == 'true'
         run: pnpm run build
 
       - name: Lint
+        if: steps.changes.outputs.source == 'true'
         run: pnpm run lint
 
       - name: Testing
+        if: steps.changes.outputs.test == 'true'
         run: pnpm run test


### PR DESCRIPTION
Add path filters to optimize GitHub Actions workflow execution.
Steps now run only when relevant files change, reducing unnecessary
CI runs and improving build times.

The filters categorize changes into node-version, pnpm, source,
build, and test groups. Each workflow step checks these filters
before executing, ensuring jobs run only when their dependencies
are modified.