### PR TITLE
chore: update Tailwind CSS IntelliSense configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,7 @@
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "tailwindCSS.experimental.classRegex": [
-    ["cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
-  ],
+  "tailwindCSS.classFunctions": ["classNames", "clsx", "cva", "twMerge"],
   "files.associations": {
     "**/styles/*.css": "tailwindcss"
   }


### PR DESCRIPTION
Replace deprecated experimental.classRegex with classFunctions to
enable Tailwind CSS IntelliSense for utility functions. This change
ensures proper autocomplete and hover support for classNames, clsx,
cva, and twMerge functions using the new recommended configuration
format.