### PR TITLE
build(deps): add @tailwindcss/oxide to onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@tailwindcss/oxide",
       "esbuild"
     ],
     "patchedDependencies": {


### PR DESCRIPTION
Configure @tailwindcss/oxide to be built from source rather than using
prebuilt binaries to ensure compatibility with the current environment
and build system requirements.