### PR TITLE
ci(renovate): add GitHub Action digest pinning configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "timezone": "Asia/Tokyo",
-  "extends": ["config:recommended", "schedule:weekdays"],
+  "extends": [
+    "config:recommended",
+    "schedule:weekdays",
+    "helpers:pinGitHubActionDigests"
+  ],
   "rangeStrategy": "pin",
   "enabledManagers": ["npm", "nvm", "devcontainer"],
   "reviewers": ["tdkn"],


### PR DESCRIPTION
Add the "helpers:pinGitHubActionDigests" preset to the Renovate configuration to ensure GitHub Actions are pinned to specific SHA digests. This improves security by preventing unexpected changes from upstream action updates and ensures reproducible CI/CD builds.

• Adds GitHub Action digest pinning preset to Renovate config
• Improves security by preventing unexpected upstream changes
• Ensures reproducible CI/CD builds