### PR TITLE
chore(renovate): enable github-actions manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
     "helpers:pinGitHubActionDigests"
   ],
   "rangeStrategy": "pin",
-  "enabledManagers": ["npm", "nvm", "devcontainer"],
+  "enabledManagers": ["npm", "nvm", "devcontainer", "github-actions"],
   "reviewers": ["tdkn"],
   "automerge": true,
   "platformAutomerge": true,


### PR DESCRIPTION
• Enabled `github-actions` manager in Renovate configuration
• Allows automatic updates of GitHub Actions dependencies in workflow files
• Improves security and maintainability of CI/CD pipelines