### PR TITLE
docs: remove notes section from swiftui safearea inset article

### DIFF
--- a/posts/2025/swiftui-safearea-inset.mdx
+++ b/posts/2025/swiftui-safearea-inset.mdx
@@ -65,8 +65,3 @@ struct ContentView: View {
 
 - Home Indicator あり（Face ID デバイス）→ Safe Area があるので追加の `padding` は不要
 - Home Indicator なし（iPhone SE など）→ Bottom Safe Area が無いため 16pt の余白を確保
-
-## 注意点と工夫
-
-- 取得タイミング: Safe Area はビューがまだ表示されていない段階では 0 になる場合があります。より動的に扱いたい場合は `GeometryReader` や `safeAreaInset` を組み合わせて `Environment` を更新するのも手です。
-- 画面回転やレイアウト変化: デバイスの回転や `TabView` の有無で Safe Area が変わることがあります。必要に応じて上位のビューで動的に環境値を更新しましょう。


### PR DESCRIPTION
Remove the "注意点と工夫" (considerations and techniques) section
containing information about safe area timing and dynamic updates.
This simplifies the article by focusing on the core implementation
without advanced usage patterns.