### PR TITLE
chore(workspace): add oxfmt to minimumReleaseAgeExclude list

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude:
+  - "oxfmt"
   - "@oxlint/*"
   - "@oxfmt/*"
   - "@oxlint-tsgolint/*"


### PR DESCRIPTION
- Add `"oxfmt"` package to the `minimumReleaseAgeExclude` list in `pnpm-workspace.yaml`
- Exempts `oxfmt` from the minimum release age requirement, consistent with the existing `@oxfmt/*` scoped packages exclusion