### PR TITLE
ci(vercel): update vercel.json configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
-  "github": {
-    "enabled": true,
-    "silent": false
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": true
   }
 }


### PR DESCRIPTION
## What?

- Replace deprecated `github` block with new `git` schema format in `vercel.json`
- Add `$schema` reference for validation and IDE support
- Migrate `enabled/silent` flags to `deploymentEnabled` property under `git`

## Why?

- The `github` block is deprecated in Vercel's configuration

## How?

- Updated `vercel.json` to use the new `git` schema structure with `deploymentEnabled` property