### PR TITLE
refactor(config): migrate next.config to typescript

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ pnpm fix:oxfmt        # Format with oxfmt
 
 3. **Styling**: Tailwind CSS v4 with PostCSS. MDX content uses `src/styles/mdx.css`.
 
-4. **Code Highlighting**: `rehype-pretty-code` with Shiki (theme `dracula-soft` in `next.config.mjs`).
+4. **Code Highlighting**: `rehype-pretty-code` with Shiki (theme `dracula-soft` in `next.config.ts`).
 
 5. **Testing**: Vitest with React Testing Library; tests run with `TZ=Asia/Tokyo`.
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,5 @@
-// @ts-check
 import createMDX from "@next/mdx";
+import type { NextConfig } from "next";
 
 const withMDX = createMDX({
   options: {
@@ -8,8 +8,7 @@ const withMDX = createMDX({
   },
 });
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: NextConfig = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   poweredByHeader: false,
   async redirects() {


### PR DESCRIPTION
## What?
- Migrated `next.config` from `.mjs` with JSDoc type annotations to native TypeScript (`.ts`)

## Why?
- Improves type safety and IDE support with native TypeScript types over JSDoc annotations

## How?
- Removed `// @ts-check` comment (no longer needed with `.ts` extension)
- Replaced JSDoc `@type {import('next').NextConfig}` with an explicit `import type { NextConfig } from "next"`
- Updated `AGENTS.md` reference from `next.config.mjs` to `next.config.ts`