### PR TITLE
refactor(profile): use type-only import for ComponentPropsWithoutRef

### DIFF
--- a/src/components/profile.tsx
+++ b/src/components/profile.tsx
@@ -8,7 +8,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
 import NextLink from "next/link";
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 
 import { Link } from "~/components/link";
 import { classNames } from "~/lib/style";


### PR DESCRIPTION
## What?
- Replaced value import with `import type` for `ComponentPropsWithoutRef` in the profile component

## Why?
- Makes the intent explicit that it's a type-only import
- Allows bundlers and TypeScript to safely erase the import at compile time without side-effect concerns

## How?
- Changed `import { ComponentPropsWithoutRef }` to `import type { ComponentPropsWithoutRef }`