### PR TITLE
chore: migrate pnpm to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,5 @@
   "volta": {
     "node": "24.15.0"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.0.9"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,9 @@ minimumReleaseAgeExclude:
   - "@oxlint-tsgolint/*"
   # Renovate security update: next@16.2.3
   - next@16.2.3
-
-onlyBuiltDependencies:
-  - "@tailwindcss/oxide"
-  - "esbuild"
-  - "sharp"
-  - "unrs-resolver"
+allowBuilds:
+  "@tailwindcss/oxide": true
+  esbuild: true
+  msw: false
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## What?

- Upgraded the project package manager from `pnpm@10.33.2` to `pnpm@11.0.9`.
- Migrated build-script approval config from `onlyBuiltDependencies` to pnpm v11's `allowBuilds` map.
- Explicitly disallowed the transitive `msw` postinstall script because this project does not configure `msw.workerDirectory`.

## Why?

pnpm v11 removes the older build-dependency settings and expects build script approvals to be represented through `allowBuilds` in `pnpm-workspace.yaml`. Updating this config keeps installs compatible with pnpm 11 while preserving the previous explicit allowlist behavior.

## How?

- Ran the pnpm v10 to v11 migration codemod and reviewed the resulting config changes.
- Refreshed install state with `pnpm install --frozen-lockfile --store-dir /Users/tdkn/Library/pnpm/store`.
- Verified with `pnpm run lint`, `pnpm run test`, and `pnpm run build`.
- Confirmed `pnpm-lock.yaml` remains unchanged.
