### PR TITLE
Fix devcontainer Node feature tag detection

### DIFF
--- a/scripts/check-node-version.sh
+++ b/scripts/check-node-version.sh
@@ -14,7 +14,10 @@ get_versions() {
     const content = fs.readFileSync('.devcontainer/devcontainer.json', 'utf8');
     const json = content.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
     const parsed = JSON.parse(json);
-    parsed.features['ghcr.io/devcontainers/features/node:1'].version;
+    const nodeFeature = Object.entries(parsed.features ?? {}).find(([name]) =>
+      /^ghcr\.io\/devcontainers\/features\/node(?::.+)?$/.test(name),
+    );
+    nodeFeature?.[1]?.version;
   ")
 }
 


### PR DESCRIPTION
## What?

- Make `scripts/check-node-version.sh` detect the devcontainer Node feature by image name instead of hardcoding the `:1` feature tag.
- Keep the existing `.nvmrc`, Volta, and devcontainer Node version comparison behavior unchanged.

## Why?

Renovate updates such as `ghcr.io/devcontainers/features/node:1` to `ghcr.io/devcontainers/features/node:2` only change the devcontainer feature major tag, but the check script looked up the old key exactly and failed before reading the configured Node.js version.

## How?

- Search `.devcontainer/devcontainer.json` features for `ghcr.io/devcontainers/features/node` with an optional tag.
- Read `version` from the matched feature entry.
- Verified with `bash ./scripts/check-node-version.sh` and a temporary devcontainer copy where the Node feature tag was changed to `:2`.