### PR TITLE
[codex] Serve markdown source URLs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -40,6 +40,14 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  rewrites() {
+    return [
+      {
+        destination: "/api/markdown/:year/:slug",
+        source: "/:year(\\d{4})/:slug.md",
+      },
+    ];
+  },
 };
 
 export default withMDX(nextConfig);

--- a/src/__tests__/mdx.test.tsx
+++ b/src/__tests__/mdx.test.tsx
@@ -60,4 +60,15 @@ describe("MDX posts", () => {
     expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
     await expect(response.text()).resolves.toContain("## 背景");
   });
+
+  it("returns not found for missing markdown posts", async () => {
+    const response = await GET(new Request("http://localhost/api/markdown/2999/missing-post"), {
+      params: Promise.resolve({
+        slug: "missing-post",
+        year: "2999",
+      }),
+    });
+
+    expect(response.status).toBe(404);
+  });
 });

--- a/src/__tests__/mdx.test.tsx
+++ b/src/__tests__/mdx.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { getAllPosts } from "~/lib/mdx";
+import { getAllPosts, getPostMarkdown } from "~/lib/mdx";
+import { GET } from "../app/api/markdown/[year]/[slug]/route";
 import BlogPostPage from "../app/(blog)/[year]/[slug]/page";
 
 describe("MDX posts", () => {
@@ -34,5 +35,29 @@ describe("MDX posts", () => {
     expect(screen.getByRole("heading", { level: 1, name: "yarn patch の使い方" })).toBeTruthy();
     expect(screen.getByText("手順")).toBeTruthy();
     expect(screen.getByText(/patch:puppeteer-core@\^5\.5\.0/)).toBeTruthy();
+  });
+
+  it("reads markdown source for a local post", async () => {
+    const markdown = await getPostMarkdown("2026", "personal-agent-skills-in-project");
+
+    expect(markdown).toContain(
+      'title: "個人用の Agent Skills を Git に乗せずプロジェクト内に置く"',
+    );
+    expect(markdown).toContain("## 背景");
+  });
+
+  it("returns markdown from the markdown route handler", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/markdown/2026/personal-agent-skills-in-project"),
+      {
+        params: Promise.resolve({
+          slug: "personal-agent-skills-in-project",
+          year: "2026",
+        }),
+      },
+    );
+
+    expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+    await expect(response.text()).resolves.toContain("## 背景");
   });
 });

--- a/src/app/api/markdown/[year]/[slug]/route.ts
+++ b/src/app/api/markdown/[year]/[slug]/route.ts
@@ -1,5 +1,7 @@
 import { getPostMarkdown } from "~/lib/mdx";
 
+export const runtime = "nodejs";
+
 interface RouteContext {
   params: Promise<{
     slug: string;

--- a/src/app/api/markdown/[year]/[slug]/route.ts
+++ b/src/app/api/markdown/[year]/[slug]/route.ts
@@ -1,0 +1,23 @@
+import { getPostMarkdown } from "~/lib/mdx";
+
+interface RouteContext {
+  params: Promise<{
+    slug: string;
+    year: string;
+  }>;
+}
+
+export const GET = async (_request: Request, { params }: RouteContext) => {
+  const { slug, year } = await params;
+  const markdown = await getPostMarkdown(year, slug);
+
+  if (markdown === null) {
+    return new Response(null, { status: 404 });
+  }
+
+  return new Response(markdown, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+};

--- a/src/lib/mdx.ts
+++ b/src/lib/mdx.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { parseISO } from "date-fns";
@@ -156,4 +157,15 @@ export const getPost = cache(async (year: string, slug: string): Promise<null | 
   const { default: component } = await importPostModule(year, slug);
 
   return { component, post };
+});
+
+export const getPostMarkdown = cache(async (year: string, slug: string): Promise<null | string> => {
+  const posts = await getAllPosts();
+  const post = posts.find((entry) => entry.year === year && entry.slug === slug);
+
+  if (post === undefined) {
+    return null;
+  }
+
+  return readFile(path.join(POSTS_PATH, year, `${slug}.mdx`), "utf-8");
 });


### PR DESCRIPTION
## What?

Add support for serving a post's Markdown source from `/:year/:slug.md`.

- Add a markdown route handler that returns published local post source as `text/markdown`.
- Rewrite four-digit year `.md` URLs to the markdown API route.
- Cover source loading and route response behavior with tests.

## Why?

Readers and tools can request the Markdown version of a post directly from the public article URL by appending `.md`.

## How?

- `getPostMarkdown()` reuses the existing published-post lookup before reading the matching `posts/{year}/{slug}.mdx` file.
- `/api/markdown/[year]/[slug]` returns the source body or `404` when the post is not public.
- `next.config.ts` rewrites `/:year/:slug.md` to the API route.
- Verified with:
  - `TZ=Asia/Tokyo ./node_modules/.bin/vitest run`
  - `PATH=/Users/tdkn/git/github.com/tdkn/blog/node_modules/.bin:$PATH ./node_modules/.bin/ultracite check --type-aware --type-check`
  - `PATH=/Users/tdkn/git/github.com/tdkn/blog/node_modules/.bin:$PATH ./node_modules/.bin/next build`