### PR TITLE
chore: clean up pnpm release age config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,12 +1,5 @@
-minimumReleaseAge: 10080
+minimumReleaseAge: 10080 # 1 week
 
-minimumReleaseAgeExclude:
-  - "oxfmt"
-  - "@oxlint/*"
-  - "@oxfmt/*"
-  - "@oxlint-tsgolint/*"
-  # Renovate security update: next@16.2.3
-  - next@16.2.3
 allowBuilds:
   "@tailwindcss/oxide": true
   esbuild: true


### PR DESCRIPTION
## What?
- Removed temporary `minimumReleaseAge` exclusions that are no longer needed
- Added a human-readable comment documenting the one-week release age value

## Why?
- The temporary exclusions were no longer necessary, leaving the config cleaner and easier to maintain

## How?
- Deleted obsolete exclusion entries from the pnpm release age config
- Added an inline comment to clarify the one-week release age value