### PR TITLE
ci: run independent workflow steps in parallel

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,10 +46,10 @@ jobs:
           pnpm run fix
           git diff --exit-code
 
-      - parallel:
-          - name: Build
-            run: pnpm run build
+      - name: Build
+        run: pnpm run build
 
+      - parallel:
           - name: Lint
             run: pnpm run lint
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,27 +29,29 @@ jobs:
           cache: true
           experimental: true
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - parallel:
+          - name: Install dependencies
+            run: pnpm install --frozen-lockfile
 
-      - name: Restore Next.js cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.[jt]sx?') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
-
-      - name: Build
-        run: pnpm run build
+          - name: Restore Next.js cache
+            uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+            with:
+              path: ${{ github.workspace }}/.next/cache
+              key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.[jt]sx?') }}
+              restore-keys: |
+                ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
 
       - name: Check fix (no uncommitted changes after pnpm run fix)
         run: |
           pnpm run fix
           git diff --exit-code
 
-      - name: Lint
-        run: pnpm run lint
+      - parallel:
+          - name: Build
+            run: pnpm run build
 
-      - name: Testing
-        run: pnpm run test
+          - name: Lint
+            run: pnpm run lint
+
+          - name: Testing
+            run: pnpm run test


### PR DESCRIPTION
## What?

- Run dependency installation and Next.js cache restoration in parallel.
- Run build, lint, and test steps in parallel after the formatter check.

## Why?

Reduce GitHub Actions wall-clock time while preserving independent step logs and failure reporting.

## How?

- Keep `pnpm run fix` isolated because it can modify the worktree.
- Use GitHub Actions `parallel` groups only for steps that do not depend on each other.

## Validation

- Parsed `.github/workflows/test.yaml` with Ruby's YAML parser.
- `pnpm run lint`
- `CI=1 pnpm test` (7 tests passed)

<sub><em>This PR description was generated by an AI coding assistant.</em></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only reordering for faster CI; parallel build/lint/test assumes those jobs do not need a prior sequential build artifact beyond what install provides.
> 
> **Overview**
> **Shortens CI wall-clock time** by grouping independent steps in `.github/workflows/test.yaml` with GitHub Actions `parallel` blocks, without changing what commands run.
> 
> After checkout and mise setup, **dependency install and Next.js cache restore** now run at the same time instead of one after the other. The **`pnpm run fix` / `git diff --exit-code` check stays on its own** so formatter fixes cannot race with other steps.
> 
> **Build, lint, and test** now run in parallel **after** the fix check. Build is no longer a separate sequential step before fix; lint and test are no longer strictly after build in series, though they still only start once install (and the fix gate) have completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ce26a5e3fcf71b75a92653cd0924c1a3844a2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->