### PR TITLE
chore(deps): run Renovate weekly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "timezone": "Asia/Tokyo",
-  "extends": ["config:recommended", "schedule:weekdays", "helpers:pinGitHubActionDigests"],
+  "extends": ["config:recommended", "schedule:weekly", "helpers:pinGitHubActionDigests"],
   "rangeStrategy": "pin",
   "enabledManagers": ["npm", "mise", "devcontainer", "github-actions"],
   "reviewers": ["tdkn"],


### PR DESCRIPTION
## What?

Run Renovate on its weekly preset instead of on weekdays.

## Why?

Reduce the frequency of dependency update checks and pull requests.

## How?

Replace `schedule:weekdays` with `schedule:weekly`.

<sub><em>Generated by AI.</em></sub>