### PR TITLE
fix(next): migrate API routes to Node.js runtime

### DIFF
--- a/src/app/api/font/route.ts
+++ b/src/app/api/font/route.ts
@@ -1,7 +1,5 @@
 import { fetchFont } from "~/lib/font";
 
-export const runtime = "edge";
-
 export const GET = async (req: Request) => {
   const { pathname, searchParams } = new URL(req.url);
 

--- a/src/app/api/logo/route.tsx
+++ b/src/app/api/logo/route.tsx
@@ -1,7 +1,5 @@
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
-
 const getTheme = (value: null | string): "dark" | "light" => (value === "dark" ? "dark" : "light");
 
 export const GET = (req: Request) => {


### PR DESCRIPTION
## What?

- Remove the deprecated Edge Runtime exports from the font and logo API routes.

## Why?

- Next.js 16.3 deprecates `runtime = "edge"` for route segments and recommends the default Node.js runtime.
- The deprecated exports emitted warnings during production builds.

## How?

- Let both routes use the implicit Node.js runtime.
- Verify the migration with `pnpm build`, `pnpm lint`, and `pnpm test --run`.

<sub><em>Generated by AI.</em></sub>